### PR TITLE
Throwableなどのcatchは、エラーとしないよう修正する。

### DIFF
--- a/java/checkstyle.xml
+++ b/java/checkstyle.xml
@@ -153,7 +153,7 @@
       <property name="max" value="2"/>
     </module>
     <module name="SuperClone"/>
-    <module name="IllegalCatch"/>
+    <!-- <module name="IllegalCatch"/> -->
     <module name="IllegalThrows"/>
     <module name="PackageDeclaration"/>
     <module name="ParameterAssignment"/>


### PR DESCRIPTION
###### 修正目的
バッチの処理開始メソッドなどで、Throwableをキャッチし、エラーログ出力、Exitコードの設定などを行いたいが、
現在のcheckstyleでは下記エラーとなってしまう。このチェックは不要と判断し、エラーにならないよう修正する。
```
'Throwable' をキャッチすることは許可されていません。
```

###### 修正内容
checkstyle定義を無効とした。

###### 依頼内容
修正内容の確認、マージお願いします。